### PR TITLE
Style: 버튼 너비 px 삭제

### DIFF
--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -44,7 +44,7 @@ export const StyledButton = styled.button<{
   color: string;
 }>`
   ${({ buttonType }) => handleButtonType(buttonType)};
-  width: ${({ width }) => width}px;
+  width: ${({ width }) => width};
   height: ${({ height }) => height}px;
   color: ${({ color }) => color};
   border-radius: 30px;


### PR DESCRIPTION
## 작업 내용

- 버튼 너비값이 px로 고정되어있어서 퍼센티지를 사용할 수 없어서 px단위 삭제하였습니다.
